### PR TITLE
Add rule for endpoint resources

### DIFF
--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -20,6 +20,9 @@ rules:
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
 
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "get", "list", "patch", "update", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This change fixes an issue preventing the pod hostpath-multihost-provisioner to run properly. Command `kubectl logs hostpath-multihost-provisioner-7c75c9cb66-m29x4 -n kube-system` showed the following message: `... cannot get resource "endpoints" in API group "" in the namespace "kube-system"`

After this fix (new rule for endpoints in RBAC) pod runs ok and provisions Persistent Volumes. Note that this change might not be compatible with newer builds/not necessary. Additional info:

```bash
kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-07T21:20:10Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-07T21:12:17Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}
```